### PR TITLE
Refactor NEAR transaction handling in FireblocksService

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilnfi/sdk",
-  "version": "4.2.20",
+  "version": "4.2.21",
   "autor": "Kiln <support@kiln.fi> (https://kiln.fi)",
   "license": "BUSL-1.1",
   "description": "JavaScript sdk for Kiln API",


### PR DESCRIPTION
- Renamed  to  for clarity and updated its implementation to create transactions without waiting for completion.
- Introduced a new method  to handle transaction completion separately.
- Added a new  method that combines the creation and completion steps for NEAR transactions.
- Updated documentation comments to reflect the changes in method functionality.