### PR TITLE
chore: release 4.2.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilnfi/sdk",
-  "version": "4.2.30",
+  "version": "4.2.31",
   "autor": "Kiln <support@kiln.fi> (https://kiln.fi)",
   "license": "BUSL-1.1",
   "description": "JavaScript sdk for Kiln API",


### PR DESCRIPTION
## Why

`v4.2.31` was tagged and a GitHub Release created on #269 (restore TIA fireblocks signing), but `package.json` still read `4.2.30`, so the publish workflow failed:

```
npm notice version: 4.2.30
npm error You cannot publish over the previously published versions: 4.2.30.
```

(run: https://github.com/kilnfi/sdk-js/actions/runs/29587169777)

## Change

Bump `package.json` version `4.2.30` → `4.2.31`.

## After merge

- Move the `v4.2.31` tag onto the merge commit (currently points at #269 which still has 4.2.30).
- Re-run `publish to npm` (release re-create or `workflow_dispatch`) so 4.2.31 lands on npm.
- Then bump api-dashboard to `4.2.31` (unblocks nakamoto#59312 lint — restores `createTiaTx`/`waitForTiaTxCompletion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)